### PR TITLE
Add findLast function for array

### DIFF
--- a/src/find/test.ts
+++ b/src/find/test.ts
@@ -5,10 +5,10 @@ describe('find', function () {
   var array = [1, 2, 3]
 
   it('finds first element by condition', function () {
-    assert(find(array, (i) => i === 2) === 2)
+    assert(find(array, (i) => i > 1) === 2)
   })
 
   it('returns undefined', function () {
-    assert(find(array, (i) => i === 69) === undefined)
+    assert(find(array, (i) => i === 420) === undefined)
   })
 })

--- a/src/findLast/index.ts
+++ b/src/findLast/index.ts
@@ -1,0 +1,21 @@
+/**
+ * Returns the last matching element in an array.
+ *
+ * @param array - The array to find element in
+ * @param matcher - The function that returns true if element satisfies a condition
+ * @returns A last element that satisfies the condition
+ *
+ * @public
+ */
+export default function findLast<ElementType>(
+  array: Array<ElementType>,
+  matcher: (element: ElementType) => boolean
+): ElementType | undefined {
+  for (let i = array.length - 1; i >= 0; i--) {
+    const element = array[i]
+
+    if (matcher(element)) {
+      return element
+    }
+  }
+}

--- a/src/findLast/test.ts
+++ b/src/findLast/test.ts
@@ -1,0 +1,14 @@
+import assert from 'assert'
+import findLast from '.'
+
+describe('findLast', function () {
+  var array = [1, 2, 3]
+
+  it('finds the last element in the array', function () {
+    assert(findLast(array, (i) => i > 1) === 3)
+  })
+
+  it('returns undefined', function () {
+    assert(findLast(array, (i) => i === 420) === undefined)
+  })
+})


### PR DESCRIPTION
The PR adds `findLast` function. The function returns the last matching element in an array. 

Also, the PR fixes tests for the `find` function, now the condition in the test matches 2 elements from the array, so we can be sure that the first one is actually returned.