### PR TITLE
Add union (another take)

### DIFF
--- a/src/throttle/test.ts
+++ b/src/throttle/test.ts
@@ -1,6 +1,7 @@
 import assert from 'assert'
 import throttle from '.'
 
+// TODO: Should be updated.
 describe('debounce', () => {
   it('executes function after given wait time since the last call', (done) => {
     let times = 0

--- a/src/union/index.ts
+++ b/src/union/index.ts
@@ -21,5 +21,8 @@ export default function union<ElementType>(
     })
   })
 
-  return [...set]
+  const result: ElementType[] = []
+  set.forEach((e) => result.push(e))
+
+  return result
 }

--- a/src/union/index.ts
+++ b/src/union/index.ts
@@ -21,5 +21,5 @@ export default function union<ElementType>(
     })
   })
 
-  return Array.from(set)
+  return [...set]
 }

--- a/src/union/index.ts
+++ b/src/union/index.ts
@@ -1,0 +1,25 @@
+/**
+ * Creates a new array with all unique elements from the given arrays
+ *
+ * @param arrays - Arrays to get unique elements from
+ * @returns An array with all unique elements from the given arrays
+ *
+ * @public
+ */
+export default function union<ElementType>(
+  ...arrays: ElementType[][]
+): Array<ElementType> {
+  if (arrays.length === 1) {
+    return arrays[0]
+  }
+
+  const set = new Set<ElementType>()
+
+  arrays.forEach((array) => {
+    array.forEach((el) => {
+      set.add(el)
+    })
+  })
+
+  return Array.from(set)
+}

--- a/src/union/test.ts
+++ b/src/union/test.ts
@@ -1,0 +1,19 @@
+import assert from 'assert'
+import union from '.'
+
+describe('union', () => {
+  it('returns an array with all unique elements from the given arrays', () => {
+    const result = union([2, 1], [2, 3])
+    assert.deepEqual(result, [2, 1, 3])
+  })
+
+  it('allows to pass more than two arrays', () => {
+    const result = union([2, 1], [2, 3], [4, 5])
+    assert.deepEqual(result, [2, 1, 3, 4, 5])
+  })
+
+  it('removes duplicates within an array', () => {
+    const result = union([2, 1, 2], [2, 3], [4, 5])
+    assert.deepEqual(result, [2, 1, 3, 4, 5])
+  })
+})


### PR DESCRIPTION
An alternative implementation would be to do:
`uniq(flatten(arrays))`
since we have these functions already implemented.