### PR TITLE
Update and fix types in fromEntries

### DIFF
--- a/src/fromEntries/index.ts
+++ b/src/fromEntries/index.ts
@@ -10,10 +10,10 @@ export default function fromEntries<
   Key extends string | number,
   Value,
   Entry extends [Key, Value],
-  ReturnType extends { [key in Key]: Value }
+  ReturnType extends { [key: string]: Value }
 >(array: Entry[]): ReturnType {
-  return array.reduce((acc, cur) => {
-    acc[cur[0]] = cur[1]
+  return array.reduce((acc, [key, value]) => {
+    acc[key] = value as ReturnType[typeof key]
     return acc
-  }, {}) as ReturnType
+  }, {} as Partial<ReturnType>) as ReturnType
 }


### PR DESCRIPTION
Object keys are always strings, so the PR updates the `ReturnType` to acknowledge that. The PR also fixes a TypeScript error when assigning `value`.